### PR TITLE
Revert "Switch to Cowboy REST"

### DIFF
--- a/src/rabbit_mgmt_themes.erl
+++ b/src/rabbit_mgmt_themes.erl
@@ -23,6 +23,7 @@
 -import(rabbit_misc, [pget/2]).
 
 -include_lib("rabbitmq_management/include/rabbit_mgmt.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
 
 dispatcher() -> [].
 web_ui()     -> [{javascript, <<"themes.js">>}].


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-management-themes#4, which was meant to ship with `rabbitmq-management-236`.
